### PR TITLE
Fix packaging, custom fields support, Dockerfile, and stable pagination

### DIFF
--- a/server.py
+++ b/server.py
@@ -143,14 +143,15 @@ class SnipeITDirectAPI:
     def list(self, endpoint: str, limit: int = 50, offset: int = 0,
              search: str | None = None, sort: str | None = None,
              order: str | None = None) -> list[dict]:
-        """List resources with pagination."""
-        params = {"limit": limit, "offset": offset}
+        """List resources with pagination.
+
+        Defaults to sort=id, order=asc to ensure deterministic ordering
+        across paginated requests and prevent duplicate/missing records.
+        """
+        params = {"limit": limit, "offset": offset,
+                  "sort": sort or "id", "order": order or "asc"}
         if search:
             params["search"] = search
-        if sort:
-            params["sort"] = sort
-        if order:
-            params["order"] = order
 
         data = self._request("GET", endpoint, params=params)
         return data.get("rows", [])
@@ -682,10 +683,9 @@ def manage_assets(
                 params = {"limit": limit, "offset": offset}
                 if search:
                     params["search"] = search
-                if sort:
-                    params["sort"] = sort
-                if order:
-                    params["order"] = order
+                # Default sort=id, order=asc for stable offset-based pagination
+                params["sort"] = sort or "id"
+                params["order"] = order or "asc"
                 # Add filter parameters
                 if status_id:
                     params["status_id"] = status_id
@@ -1292,10 +1292,9 @@ def manage_consumables(
                 params = {"limit": limit, "offset": offset}
                 if search:
                     params["search"] = search
-                if sort:
-                    params["sort"] = sort
-                if order:
-                    params["order"] = order
+                # Default sort=id, order=asc for stable offset-based pagination
+                params["sort"] = sort or "id"
+                params["order"] = order or "asc"
                 
                 consumables = client.consumables.list(**params)
                 
@@ -1463,10 +1462,9 @@ def manage_categories(
                 params = {"limit": limit, "offset": offset}
                 if search:
                     params["search"] = search
-                if sort:
-                    params["sort"] = sort
-                if order:
-                    params["order"] = order
+                # Default sort=id, order=asc for stable offset-based pagination
+                params["sort"] = sort or "id"
+                params["order"] = order or "asc"
 
                 categories = client.categories.list(**params)
 
@@ -1624,10 +1622,9 @@ def manage_manufacturers(
                 params = {"limit": limit, "offset": offset}
                 if search:
                     params["search"] = search
-                if sort:
-                    params["sort"] = sort
-                if order:
-                    params["order"] = order
+                # Default sort=id, order=asc for stable offset-based pagination
+                params["sort"] = sort or "id"
+                params["order"] = order or "asc"
 
                 manufacturers = client.manufacturers.list(**params)
 
@@ -1787,10 +1784,9 @@ def manage_models(
                 params = {"limit": limit, "offset": offset}
                 if search:
                     params["search"] = search
-                if sort:
-                    params["sort"] = sort
-                if order:
-                    params["order"] = order
+                # Default sort=id, order=asc for stable offset-based pagination
+                params["sort"] = sort or "id"
+                params["order"] = order or "asc"
 
                 models = client.models.list(**params)
 
@@ -2142,10 +2138,9 @@ def manage_locations(
                 params = {"limit": limit, "offset": offset}
                 if search:
                     params["search"] = search
-                if sort:
-                    params["sort"] = sort
-                if order:
-                    params["order"] = order
+                # Default sort=id, order=asc for stable offset-based pagination
+                params["sort"] = sort or "id"
+                params["order"] = order or "asc"
 
                 locations = client.locations.list(**params)
 
@@ -3330,10 +3325,9 @@ def manage_users(
             params = {"limit": limit, "offset": offset}
             if search:
                 params["search"] = search
-            if sort:
-                params["sort"] = sort
-            if order:
-                params["order"] = order
+            # Default sort=id, order=asc for stable offset-based pagination
+            params["sort"] = sort or "id"
+            params["order"] = order or "asc"
             if username:
                 params["username"] = username
             if email:
@@ -3582,10 +3576,8 @@ def manage_components(
             params = {"limit": limit, "offset": offset}
             if search:
                 params["search"] = search
-            if sort:
-                params["sort"] = sort
-            if order:
-                params["order"] = order
+            params["sort"] = sort or "id"
+            params["order"] = order or "asc"
 
             components = api.list("components", **params)
 
@@ -3819,10 +3811,8 @@ def manage_companies(
             params = {"limit": limit, "offset": offset}
             if search:
                 params["search"] = search
-            if sort:
-                params["sort"] = sort
-            if order:
-                params["order"] = order
+            params["sort"] = sort or "id"
+            params["order"] = order or "asc"
 
             companies = api.list("companies", **params)
 
@@ -3965,10 +3955,8 @@ def manage_departments(
             params = {"limit": limit, "offset": offset}
             if search:
                 params["search"] = search
-            if sort:
-                params["sort"] = sort
-            if order:
-                params["order"] = order
+            params["sort"] = sort or "id"
+            params["order"] = order or "asc"
 
             departments = api.list("departments", **params)
 

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -64,6 +64,16 @@ class TestManageAssets:
         assert result["success"] is True
         assert result["action"] == "list"
 
+    def test_list_default_sort(self, mock_client, mock_direct_api):
+        """list() without explicit sort should default to sort=id, order=asc for stable pagination."""
+        from server import manage_assets
+        mock_direct_api._request.return_value = {"rows": [], "total": 0}
+        result = get_tool_fn(manage_assets)(action="list")
+        assert result["success"] is True
+        call_params = mock_direct_api._request.call_args[1]["params"]
+        assert call_params["sort"] == "id", "Default sort should be 'id' for stable pagination"
+        assert call_params["order"] == "asc", "Default order should be 'asc' for stable pagination"
+
     def test_list_with_filters(self, mock_client, mock_direct_api):
         from server import manage_assets
         mock_direct_api._request.return_value = {"rows": [], "total": 0}


### PR DESCRIPTION
## Summary

- **Stable pagination** — default `sort=id, order=asc` across all 11 list endpoints to prevent duplicate/missing records

## Problem: Pagination Duplicates

Without explicit `sort`, Snipe-IT API defaults to `created_at DESC`. When multiple records share the same `created_at` (bulk imports), offset-based pagination produces non-deterministic ordering between requests:

```
Request 1: offset=0,   limit=100 → records [1..100]
Request 2: offset=100, limit=100 → records [101..200]
           ↑ record 100 may "slide" into request 2 → duplicates
```

### Fix

All 11 list query paths now always send `sort=id&order=asc` unless the caller provides explicit sort/order. This makes pagination deterministic.

## Changes

| File | What |
|------|------|
| `server.py` | Custom fields in response, `extra_fields` validation, default sort/order in all list endpoints |
| `Dockerfile` | Multi-stage build, non-root user, `HEALTHCHECK` |
| `pyproject.toml` | Test dependencies (`pytest`, `pytest-asyncio`) |
| `tests/test_assets.py` | Tests for `extra_fields`, `test_list_default_sort` |
| `tests/test_error_handling.py` | Minor test fixes |

## Testing

All 282 tests pass.