### PR TITLE
Fix object schema for manage_assets inputs

### DIFF
--- a/server.py
+++ b/server.py
@@ -540,8 +540,20 @@ def manage_assets(
     asset_id: Annotated[int | None, "Asset ID (required for get, update, delete)"] = None,
     asset_tag: Annotated[str | None, "Asset tag (alternative to asset_id for get)"] = None,
     serial: Annotated[str | None, "Serial number (alternative to asset_id for get)"] = None,
-    asset_data: Annotated[AssetData | None, "Asset data for standard fields (required for create, optional for update)"] = None,
-    extra_fields: Annotated[dict | None, "Additional fields not in AssetData: asset_eol_date, custom fields (_snipeit_*), etc. For update, fields are validated against the asset's model fieldset."] = None,
+    asset_data: Annotated[
+        AssetData | None,
+        Field(
+            description="Asset data for standard fields (required for create, optional for update)",
+            json_schema_extra={"type": "object", "additionalProperties": True},
+        ),
+    ] = None,
+    extra_fields: Annotated[
+        dict[str, Any] | None,
+        Field(
+            description="Additional fields not in AssetData: asset_eol_date, custom fields (_snipeit_*), etc. For update, fields are validated against the asset's model fieldset.",
+            json_schema_extra={"type": "object", "additionalProperties": True},
+        ),
+    ] = None,
     limit: Annotated[int | None, "Number of results to return (for list action)"] = 50,
     offset: Annotated[int | None, "Number of results to skip (for list action)"] = 0,
     search: Annotated[str | None, "Search query (for list action)"] = None,

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -2,7 +2,9 @@
 
 import os
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
+
+import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -11,6 +13,22 @@ def get_tool_fn(tool):
 
 
 class TestManageAssets:
+    def test_manage_assets_schema_marks_object_inputs_as_objects(self):
+        import server
+
+        params = server.mcp._tool_manager._tools["manage_assets"].parameters["properties"]
+
+        asset_data_schema = params["asset_data"]
+        extra_fields_schema = params["extra_fields"]
+
+        assert asset_data_schema["type"] == "object"
+        assert asset_data_schema["additionalProperties"] is True
+        assert any(branch.get("$ref") == "#/$defs/AssetData" for branch in asset_data_schema["anyOf"])
+
+        assert extra_fields_schema["type"] == "object"
+        assert extra_fields_schema["additionalProperties"] is True
+        assert any(branch.get("type") == "object" for branch in extra_fields_schema["anyOf"])
+
     def test_create(self, mock_client, mock_direct_api):
         from server import manage_assets, AssetData
         mock_direct_api._request.return_value = {"status": "success", "payload": {"id": 1, "asset_tag": "LAP-001", "name": "Test Laptop"}}
@@ -95,6 +113,49 @@ class TestManageAssets:
         result = get_tool_fn(manage_assets)(action="update", asset_id=1, asset_data=AssetData(name="Updated"))
         assert result["success"] is True
         assert result["action"] == "update"
+
+    @pytest.mark.asyncio
+    async def test_tool_run_accepts_dict_asset_data(self, mock_client, mock_direct_api):
+        import server
+
+        tool = server.mcp._tool_manager._tools["manage_assets"]
+        mock_direct_api._request.return_value = {"status": "success", "payload": {"id": 1, "name": "Test Laptop"}}
+
+        result = await tool.run({
+            "action": "create",
+            "asset_data": {"status_id": 1, "model_id": 5, "name": "Test Laptop"},
+        })
+
+        assert result.structured_content["success"] is True
+        assert result.structured_content["action"] == "create"
+        mock_direct_api._request.assert_called_once_with(
+            "POST",
+            "hardware",
+            json={"status_id": 1, "model_id": 5, "name": "Test Laptop"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_tool_run_accepts_dict_extra_fields(self, mock_client, mock_direct_api):
+        import server
+
+        tool = server.mcp._tool_manager._tools["manage_assets"]
+        mock_direct_api._request.side_effect = [
+            {"id": 1, "custom_fields": {"Hostname": {"field": "_snipeit_hostname_2"}}},
+            {"status": "success", "payload": {"id": 1, "name": "Updated"}},
+        ]
+
+        result = await tool.run({
+            "action": "update",
+            "asset_id": 1,
+            "extra_fields": {"_snipeit_hostname_2": "FL142"},
+        })
+
+        assert result.structured_content["success"] is True
+        assert result.structured_content["action"] == "update"
+        assert mock_direct_api._request.call_args_list == [
+            call("GET", "hardware/1"),
+            call("PATCH", "hardware/1", json={"_snipeit_hostname_2": "FL142"}),
+        ]
 
     def test_update_missing_id(self, mock_client):
         from server import manage_assets, AssetData


### PR DESCRIPTION
## Summary

The `asset_data` and `extra_fields` parameters on `manage_assets` were typed as `AssetData | None` / `dict | None` but the JSON Schema FastMCP emitted didn't mark them as `type: object`. Some MCP clients reject dict-shaped inputs that don't carry an explicit object type in the schema, so callers couldn't pass either parameter in practice.

## Fix

Wrap both annotations in `Field(..., json_schema_extra={"type": "object", "additionalProperties": True})` so the emitted schema explicitly says these branches accept arbitrary object payloads. Behaviour is otherwise unchanged.

## Credit

Cherry-picked from @grupataurus's fork (commit f80e8a0). I'm forwarding it here unchanged so the fix reaches upstream — original authorship is preserved in the commit metadata, and the commit body retains the `Co-authored-by:` trailer.

## Test plan

- [x] Pre-existing test suite passes (285 tests on the upstream tree + 2 new tests added in the cherry-picked commit covering the schema shape and dict-typed inputs)
- [x] Diff is purely additive in schema metadata; no runtime behaviour changes