### PR TITLE
Fix accessory checkout payload — use polymorphic target fields

### DIFF
--- a/src/snipeit_mcp/schemas.py
+++ b/src/snipeit_mcp/schemas.py
@@ -213,8 +213,20 @@ class AccessoryData(BaseModel):
 
 
 class AccessoryCheckout(BaseModel):
-    """Model for accessory checkout operations."""
-    assigned_to: int | None = Field(None, description="User ID to checkout to")
+    """Model for accessory checkout operations.
+
+    Snipe-IT's accessory checkout endpoint accepts a polymorphic target
+    (``assigned_user`` | ``assigned_asset`` | ``assigned_location``) — exactly
+    one of which must be provided. We expose that as ``checkout_to_type`` +
+    ``assigned_to_id`` to match the shape of :class:`CheckoutData` for assets,
+    and translate to the wire field name in the tool layer.
+    """
+    checkout_to_type: Literal["user", "asset", "location"] = Field(
+        ...,
+        description="Type of entity to checkout the accessory to"
+    )
+    assigned_to_id: int = Field(..., description="ID of the user/asset/location to checkout to")
+    checkout_qty: int | None = Field(None, description="Quantity to checkout (server defaults to 1)")
     note: str | None = Field(None, description="Checkout notes")
 
 

--- a/src/snipeit_mcp/tools/inventory.py
+++ b/src/snipeit_mcp/tools/inventory.py
@@ -368,11 +368,13 @@ def accessory_operations(
 ) -> dict[str, Any]:
     """Perform checkout/checkin operations on accessories.
 
-    Accessories can be checked out to users. Each checkout decrements the available
-    quantity, and checkin increments it back.
+    Accessories can be checked out to a user, asset, or location. Each
+    checkout decrements the available quantity, and checkin increments it
+    back.
 
     Operations:
-    - checkout: Checkout an accessory to a user (requires checkout_data with assigned_to)
+    - checkout: Checkout an accessory to a user/asset/location (requires
+      checkout_data with checkout_to_type and assigned_to_id)
     - checkin: Checkin an accessory (requires checkout_id from the checkout record)
     - list_checkouts: List all users who have this accessory checked out
 
@@ -386,20 +388,24 @@ def accessory_operations(
             if not checkout_data:
                 return {"success": False, "error": "checkout_data is required for checkout action"}
 
-            if not checkout_data.assigned_to:
-                return {
-                    "success": False,
-                    "error": "assigned_to (user ID) is required for checkout"
-                }
+            target_field = {
+                "user": "assigned_user",
+                "asset": "assigned_asset",
+                "location": "assigned_location",
+            }[checkout_data.checkout_to_type]
+            checkout_payload: dict[str, Any] = {target_field: checkout_data.assigned_to_id}
+            if checkout_data.checkout_qty is not None:
+                checkout_payload["checkout_qty"] = checkout_data.checkout_qty
+            if checkout_data.note is not None:
+                checkout_payload["note"] = checkout_data.note
 
-            checkout_payload = {k: v for k, v in checkout_data.model_dump().items() if v is not None}
             result = api._request("POST", f"accessories/{accessory_id}/checkout", json=checkout_payload)
 
             return {
                 "success": True,
                 "action": "checkout",
                 "accessory_id": accessory_id,
-                "message": f"Accessory checked out to user {checkout_data.assigned_to}",
+                "message": f"Accessory checked out to {checkout_data.checkout_to_type} {checkout_data.assigned_to_id}",
                 "result": result
             }
 

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -182,26 +182,51 @@ class TestManageAccessories:
         assert result["success"] is True
 
 class TestAccessoryOperations:
-    def test_checkout(self, mock_direct_api):
+    def test_checkout_to_user(self, mock_direct_api):
         from snipeit_mcp import accessory_operations, AccessoryCheckout
         mock_direct_api._request.return_value = {"status": "success"}
         result = get_tool_fn(accessory_operations)(
             action="checkout", accessory_id=1,
-            checkout_data=AccessoryCheckout(assigned_to=5)
+            checkout_data=AccessoryCheckout(checkout_to_type="user", assigned_to_id=5)
         )
         assert result["success"] is True
+        # Verify wire payload uses polymorphic field name (regression guard for the
+        # bug where we were sending assigned_to and the API rejected it).
+        _, kwargs = mock_direct_api._request.call_args
+        assert kwargs["json"] == {"assigned_user": 5}
+
+    def test_checkout_to_asset(self, mock_direct_api):
+        from snipeit_mcp import accessory_operations, AccessoryCheckout
+        mock_direct_api._request.return_value = {"status": "success"}
+        result = get_tool_fn(accessory_operations)(
+            action="checkout", accessory_id=1,
+            checkout_data=AccessoryCheckout(checkout_to_type="asset", assigned_to_id=42)
+        )
+        assert result["success"] is True
+        _, kwargs = mock_direct_api._request.call_args
+        assert kwargs["json"] == {"assigned_asset": 42}
+
+    def test_checkout_to_location_with_qty_and_note(self, mock_direct_api):
+        from snipeit_mcp import accessory_operations, AccessoryCheckout
+        mock_direct_api._request.return_value = {"status": "success"}
+        result = get_tool_fn(accessory_operations)(
+            action="checkout", accessory_id=1,
+            checkout_data=AccessoryCheckout(
+                checkout_to_type="location", assigned_to_id=7,
+                checkout_qty=3, note="batch handout",
+            )
+        )
+        assert result["success"] is True
+        _, kwargs = mock_direct_api._request.call_args
+        assert kwargs["json"] == {
+            "assigned_location": 7,
+            "checkout_qty": 3,
+            "note": "batch handout",
+        }
 
     def test_checkout_missing_data(self, mock_direct_api):
         from snipeit_mcp import accessory_operations
         result = get_tool_fn(accessory_operations)(action="checkout", accessory_id=1)
-        assert result["success"] is False
-
-    def test_checkout_missing_assigned_to(self, mock_direct_api):
-        from snipeit_mcp import accessory_operations, AccessoryCheckout
-        result = get_tool_fn(accessory_operations)(
-            action="checkout", accessory_id=1,
-            checkout_data=AccessoryCheckout()
-        )
         assert result["success"] is False
 
     def test_checkin(self, mock_direct_api):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -134,10 +134,28 @@ class TestAccessoryData:
         assert a.qty == 50
 
 class TestAccessoryCheckout:
-    def test_valid(self):
+    def test_valid_user(self):
         from snipeit_mcp import AccessoryCheckout
-        a = AccessoryCheckout(assigned_to=5, note="For project")
-        assert a.assigned_to == 5
+        a = AccessoryCheckout(checkout_to_type="user", assigned_to_id=5, note="For project")
+        assert a.checkout_to_type == "user"
+        assert a.assigned_to_id == 5
+
+    def test_valid_asset(self):
+        from snipeit_mcp import AccessoryCheckout
+        a = AccessoryCheckout(checkout_to_type="asset", assigned_to_id=42)
+        assert a.checkout_to_type == "asset"
+
+    def test_valid_location(self):
+        from snipeit_mcp import AccessoryCheckout
+        a = AccessoryCheckout(checkout_to_type="location", assigned_to_id=7, checkout_qty=3)
+        assert a.checkout_qty == 3
+
+    def test_missing_required_fields(self):
+        import pytest
+        from pydantic import ValidationError
+        from snipeit_mcp import AccessoryCheckout
+        with pytest.raises(ValidationError):
+            AccessoryCheckout()
 
 class TestUserData:
     def test_valid(self):


### PR DESCRIPTION
## Summary

Snipe-IT's `POST /api/v1/accessories/{id}/checkout` endpoint validates a polymorphic target field — exactly one of `assigned_user`, `assigned_asset`, or `assigned_location` must be present (see [`AccessoryCheckoutRequest::rules()`](https://github.com/snipe/snipe-it/blob/master/app/Http/Requests/AccessoryCheckoutRequest.php) upstream). The current `AccessoryCheckout` schema sends `assigned_to` instead, so every `accessory_operations(action="checkout", ...)` call returns an API validation error against a live Snipe-IT v8 instance. The bug was caught by a colleague trying to check out an accessory through the MCP and getting back *"sie erwartet eines der Felder `assigned_user`, `assigned_asset` oder `assigned_location`, aber das Tool unterstützt nur `assigned_to`"*.

### What changes

- `AccessoryCheckout` is refactored to mirror the polymorphic shape used by `CheckoutData` for assets: `checkout_to_type` (`"user" | "asset" | "location"`) + `assigned_to_id`. The schema also gains optional `checkout_qty` since the API accepts it.
- `accessory_operations` translates `checkout_to_type` to the polymorphic wire field name (`assigned_user` / `assigned_asset` / `assigned_location`) before POSTing.
- The dead "assigned_to is required" check is removed — Pydantic now enforces this via required fields.

### What deliberately doesn't change

Before refactoring, I verified all three checkout endpoints against the Snipe-IT controllers/form requests. License seats and components are already correct on `main`:

- **`LicenseSeatCheckout`** already uses `assigned_to` (user) + `asset_id` (asset), which matches [`LicenseSeatsController::update()`](https://github.com/snipe/snipe-it/blob/master/app/Http/Controllers/Api/LicenseSeatsController.php)'s mutually-exclusive validation rules exactly.
- **`ComponentCheckout`** already uses `assigned_to` as the asset ID + `assigned_qty` + `note`, which matches [`ComponentsController::checkout()`](https://github.com/snipe/snipe-it/blob/master/app/Http/Controllers/Api/ComponentsController.php) exactly. Components are asset-only by design — no polymorphic target.

Scoping this PR to accessories keeps the surface small and avoids changing endpoints that aren't broken.

### Why the existing tests didn't catch it

The previous `test_checkout` only asserted `result["success"] is True`, which a mocked `_request` returns regardless of payload contents. The three new tests on `accessory_operations` assert the exact wire JSON for each target type, so a future schema regression would fail loudly.

## Test plan

- [x] All 295 existing tests pass after the change.
- [x] Three new wire-payload assertions verify `assigned_user` / `assigned_asset` / `assigned_location` field names go on the wire as expected.
- [x] Schema validation tests cover all three `checkout_to_type` values plus the required-field error path.
- [x] `ruff check --select=F` clean on touched files (the one pre-existing F401 in `inventory.py` is unrelated and out of scope).
- [ ] Manual smoke test against a live Snipe-IT v8 instance to confirm an accessory checkout to a user now succeeds end-to-end.