### PR TITLE
Release 1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A comprehensive [Model Context Protocol (MCP)](https://modelcontextprotocol.io/)
 ### Inventory Tracking
 - **Consumables**: Complete management of consumable items
 - **Components**: Manage components with checkout/checkin to assets
-- **Accessories**: Track accessories with checkout/checkin to users
+- **Accessories**: Track accessories with checkout/checkin to users, assets, or locations
 
 ### Users & Organization
 - **Users**: Full user management including restore and current user endpoint
@@ -180,7 +180,7 @@ Add to your Cursor MCP settings with the same configuration format as above.
 | `manage_components` | CRUD operations for components |
 | `component_operations` | Checkout/checkin components to assets |
 | `manage_accessories` | CRUD operations for accessories |
-| `accessory_operations` | Checkout/checkin accessories to users |
+| `accessory_operations` | Checkout/checkin accessories to users, assets, or locations |
 
 ### User & Organization Tools (6)
 
@@ -385,6 +385,25 @@ All list endpoints return pagination metadata:
 ```
 
 ## Architecture
+
+```
+src/snipeit_mcp/
+├── __init__.py        # Public API re-exports
+├── __main__.py        # Entry point (snipeit-mcp script)
+├── mcp_server.py      # FastMCP instance + tool whitelist
+├── client.py          # SnipeIT API clients
+├── schemas.py         # Pydantic input schemas
+└── tools/             # 9 modules grouped by Snipe-IT domain
+    ├── assets.py
+    ├── inventory.py
+    ├── foundational.py
+    ├── licenses.py
+    ├── people.py
+    ├── custom_fields.py
+    ├── reports.py
+    ├── imports.py
+    └── system.py
+```
 
 Built with:
 - **[FastMCP](https://gofastmcp.com)**: Python framework for MCP servers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "snipeit-mcp"
-version = "1.5.0"
+version = "1.6.0"
 description = "MCP server for Snipe-IT inventory management system"
 readme = "README.md"
 license = "MIT"

--- a/src/snipeit_mcp/schemas.py
+++ b/src/snipeit_mcp/schemas.py
@@ -213,8 +213,20 @@ class AccessoryData(BaseModel):
 
 
 class AccessoryCheckout(BaseModel):
-    """Model for accessory checkout operations."""
-    assigned_to: int | None = Field(None, description="User ID to checkout to")
+    """Model for accessory checkout operations.
+
+    Snipe-IT's accessory checkout endpoint accepts a polymorphic target
+    (``assigned_user`` | ``assigned_asset`` | ``assigned_location``) — exactly
+    one of which must be provided. We expose that as ``checkout_to_type`` +
+    ``assigned_to_id`` to match the shape of :class:`CheckoutData` for assets,
+    and translate to the wire field name in the tool layer.
+    """
+    checkout_to_type: Literal["user", "asset", "location"] = Field(
+        ...,
+        description="Type of entity to checkout the accessory to"
+    )
+    assigned_to_id: int = Field(..., description="ID of the user/asset/location to checkout to")
+    checkout_qty: int | None = Field(None, description="Quantity to checkout (server defaults to 1)")
     note: str | None = Field(None, description="Checkout notes")
 
 

--- a/src/snipeit_mcp/tools/inventory.py
+++ b/src/snipeit_mcp/tools/inventory.py
@@ -368,11 +368,13 @@ def accessory_operations(
 ) -> dict[str, Any]:
     """Perform checkout/checkin operations on accessories.
 
-    Accessories can be checked out to users. Each checkout decrements the available
-    quantity, and checkin increments it back.
+    Accessories can be checked out to a user, asset, or location. Each
+    checkout decrements the available quantity, and checkin increments it
+    back.
 
     Operations:
-    - checkout: Checkout an accessory to a user (requires checkout_data with assigned_to)
+    - checkout: Checkout an accessory to a user/asset/location (requires
+      checkout_data with checkout_to_type and assigned_to_id)
     - checkin: Checkin an accessory (requires checkout_id from the checkout record)
     - list_checkouts: List all users who have this accessory checked out
 
@@ -386,20 +388,24 @@ def accessory_operations(
             if not checkout_data:
                 return {"success": False, "error": "checkout_data is required for checkout action"}
 
-            if not checkout_data.assigned_to:
-                return {
-                    "success": False,
-                    "error": "assigned_to (user ID) is required for checkout"
-                }
+            target_field = {
+                "user": "assigned_user",
+                "asset": "assigned_asset",
+                "location": "assigned_location",
+            }[checkout_data.checkout_to_type]
+            checkout_payload: dict[str, Any] = {target_field: checkout_data.assigned_to_id}
+            if checkout_data.checkout_qty is not None:
+                checkout_payload["checkout_qty"] = checkout_data.checkout_qty
+            if checkout_data.note is not None:
+                checkout_payload["note"] = checkout_data.note
 
-            checkout_payload = {k: v for k, v in checkout_data.model_dump().items() if v is not None}
             result = api._request("POST", f"accessories/{accessory_id}/checkout", json=checkout_payload)
 
             return {
                 "success": True,
                 "action": "checkout",
                 "accessory_id": accessory_id,
-                "message": f"Accessory checked out to user {checkout_data.assigned_to}",
+                "message": f"Accessory checked out to {checkout_data.checkout_to_type} {checkout_data.assigned_to_id}",
                 "result": result
             }
 

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -182,26 +182,51 @@ class TestManageAccessories:
         assert result["success"] is True
 
 class TestAccessoryOperations:
-    def test_checkout(self, mock_direct_api):
+    def test_checkout_to_user(self, mock_direct_api):
         from snipeit_mcp import accessory_operations, AccessoryCheckout
         mock_direct_api._request.return_value = {"status": "success"}
         result = get_tool_fn(accessory_operations)(
             action="checkout", accessory_id=1,
-            checkout_data=AccessoryCheckout(assigned_to=5)
+            checkout_data=AccessoryCheckout(checkout_to_type="user", assigned_to_id=5)
         )
         assert result["success"] is True
+        # Verify wire payload uses polymorphic field name (regression guard for the
+        # bug where we were sending assigned_to and the API rejected it).
+        _, kwargs = mock_direct_api._request.call_args
+        assert kwargs["json"] == {"assigned_user": 5}
+
+    def test_checkout_to_asset(self, mock_direct_api):
+        from snipeit_mcp import accessory_operations, AccessoryCheckout
+        mock_direct_api._request.return_value = {"status": "success"}
+        result = get_tool_fn(accessory_operations)(
+            action="checkout", accessory_id=1,
+            checkout_data=AccessoryCheckout(checkout_to_type="asset", assigned_to_id=42)
+        )
+        assert result["success"] is True
+        _, kwargs = mock_direct_api._request.call_args
+        assert kwargs["json"] == {"assigned_asset": 42}
+
+    def test_checkout_to_location_with_qty_and_note(self, mock_direct_api):
+        from snipeit_mcp import accessory_operations, AccessoryCheckout
+        mock_direct_api._request.return_value = {"status": "success"}
+        result = get_tool_fn(accessory_operations)(
+            action="checkout", accessory_id=1,
+            checkout_data=AccessoryCheckout(
+                checkout_to_type="location", assigned_to_id=7,
+                checkout_qty=3, note="batch handout",
+            )
+        )
+        assert result["success"] is True
+        _, kwargs = mock_direct_api._request.call_args
+        assert kwargs["json"] == {
+            "assigned_location": 7,
+            "checkout_qty": 3,
+            "note": "batch handout",
+        }
 
     def test_checkout_missing_data(self, mock_direct_api):
         from snipeit_mcp import accessory_operations
         result = get_tool_fn(accessory_operations)(action="checkout", accessory_id=1)
-        assert result["success"] is False
-
-    def test_checkout_missing_assigned_to(self, mock_direct_api):
-        from snipeit_mcp import accessory_operations, AccessoryCheckout
-        result = get_tool_fn(accessory_operations)(
-            action="checkout", accessory_id=1,
-            checkout_data=AccessoryCheckout()
-        )
         assert result["success"] is False
 
     def test_checkin(self, mock_direct_api):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -134,10 +134,28 @@ class TestAccessoryData:
         assert a.qty == 50
 
 class TestAccessoryCheckout:
-    def test_valid(self):
+    def test_valid_user(self):
         from snipeit_mcp import AccessoryCheckout
-        a = AccessoryCheckout(assigned_to=5, note="For project")
-        assert a.assigned_to == 5
+        a = AccessoryCheckout(checkout_to_type="user", assigned_to_id=5, note="For project")
+        assert a.checkout_to_type == "user"
+        assert a.assigned_to_id == 5
+
+    def test_valid_asset(self):
+        from snipeit_mcp import AccessoryCheckout
+        a = AccessoryCheckout(checkout_to_type="asset", assigned_to_id=42)
+        assert a.checkout_to_type == "asset"
+
+    def test_valid_location(self):
+        from snipeit_mcp import AccessoryCheckout
+        a = AccessoryCheckout(checkout_to_type="location", assigned_to_id=7, checkout_qty=3)
+        assert a.checkout_qty == 3
+
+    def test_missing_required_fields(self):
+        import pytest
+        from pydantic import ValidationError
+        from snipeit_mcp import AccessoryCheckout
+        with pytest.raises(ValidationError):
+            AccessoryCheckout()
 
 class TestUserData:
     def test_valid(self):


### PR DESCRIPTION
## Release 1.6.0

### Highlights

**Package restructure** — The monolithic `server.py` (5,443 lines) has been split into a clean `src/snipeit_mcp/` package with 9 domain-grouped tool modules. No functional changes to the public API; all 39 tools work exactly as before.

**Accessory checkout fix** — `accessory_operations(action="checkout")` now correctly sends the polymorphic target fields (`assigned_user` / `assigned_asset` / `assigned_location`) that Snipe-IT v8 expects. Previously it sent `assigned_to`, which the API rejected with a validation error.

### What's Changed

#### Bug Fixes
- **Fix accessory checkout payload** — Use polymorphic target fields (`checkout_to_type` + `assigned_to_id`) matching the Snipe-IT API's `AccessoryCheckoutRequest` validation rules. Accessories can now be checked out to users, assets, or locations. (#12 — @stephaneberle9)
- **Fix NameError in file upload/download paths** — Four tool modules (`foundational`, `imports`, `licenses`, `system`) referenced bare `requests` and `SNIPEIT_TOKEN` without importing them, causing `NameError` at runtime on upload/download code paths. (#10 — @stephaneberle9)

#### Refactoring
- **Restructure into `src/snipeit_mcp/` package** — Split `server.py` into focused modules: `client.py` (API clients), `schemas.py` (Pydantic models), `mcp_server.py` (FastMCP instance), and `tools/` (9 domain modules). Updated `pyproject.toml`, `Dockerfile`, and all tests. (#10 — @stephaneberle9)

#### Tests
- 4 new wire-payload assertions for accessory checkout (user, asset, location targets + missing data)
- 6 new file-transfer tests covering upload/download paths across all 4 affected modules
- Total: **295 tests**, all passing

#### Docs
- Updated README with package layout diagram and accessory polymorphic checkout descriptions

### Contributors
- @stephaneberle9 (PR #10, PR #12)
- @samspade21 (pagination fix merged in v1.5.0, ported to new layout in #10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)