### PR TITLE
Fix status_summary for Snipe-IT v8; surface wrapped API errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from clients — and behaves the same as before from a user's perspective. The
   public tool set, input schemas, and stdio transport are unchanged.
 
+### Fixed
+- `status_summary` no longer calls the removed `statuslabels/assets` endpoint
+  (gone in Snipe-IT v8); it now aggregates `assets_count` from the paginated
+  `statuslabels` listing and returns `summary`, `status_labels`, and
+  `total_assets`. Fixes #18.
+- Direct API requests now raise an error when Snipe-IT returns HTTP 200 with a
+  `{"status": "error", ...}` payload, so wrapped API failures are no longer
+  reported as `"success": true`.
+
 ## [1.2.0] - 2025-01-21
 
 ### Added

--- a/src/snipeit_mcp/client.py
+++ b/src/snipeit_mcp/client.py
@@ -100,7 +100,14 @@ class SnipeITDirectAPI:
             raise SnipeITValidationError(str(error_data.get("messages", error_data)))
 
         response.raise_for_status()
-        return response.json()
+        data = response.json()
+        # Snipe-IT returns HTTP 200 with {"status": "error", "messages": ...}
+        # for many failures (e.g. unknown sub-resource); surface those as
+        # errors instead of letting callers report them as success.
+        if isinstance(data, dict) and data.get("status") == "error":
+            messages = data.get("messages") or "Unknown API error"
+            raise SnipeITException(str(messages))
+        return data
 
     def list(self, endpoint: str, limit: int = 50, offset: int = 0,
              search: str | None = None, sort: str | None = None,

--- a/src/snipeit_mcp/tools/reports.py
+++ b/src/snipeit_mcp/tools/reports.py
@@ -159,11 +159,29 @@ def status_summary() -> dict[str, Any]:
     """
     try:
         api = _client.get_direct_api()
-        result = api._request("GET", "statuslabels/assets")
+
+        # Aggregate assets_count from the statuslabels listing; the old
+        # statuslabels/assets endpoint no longer exists in Snipe-IT v8.
+        summary: dict[str, int] = {}
+        offset = 0
+        limit = 500
+        while True:
+            result = api._request(
+                "GET", "statuslabels", params={"limit": limit, "offset": offset}
+            )
+            rows = result.get("rows", []) if isinstance(result, dict) else []
+            for row in rows:
+                summary[str(row.get("name", "?"))] = int(row.get("assets_count") or 0)
+            total = result.get("total", len(rows)) if isinstance(result, dict) else 0
+            offset += len(rows)
+            if not rows or offset >= total:
+                break
 
         return {
             "success": True,
-            "summary": result
+            "summary": summary,
+            "status_labels": len(summary),
+            "total_assets": sum(summary.values()),
         }
 
     except SnipeITNotFoundError as e:

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -166,10 +166,42 @@ class TestActivityReports:
 class TestStatusSummary:
     def test_basic(self, mock_direct_api):
         from snipeit_mcp import status_summary
-        mock_direct_api._request.return_value = {"Deployed": 50, "Pending": 10}
+        mock_direct_api._request.return_value = {
+            "total": 2,
+            "rows": [
+                {"name": "Ready to Deploy", "assets_count": 50},
+                {"name": "Pending", "assets_count": 10},
+            ],
+        }
         result = get_tool_fn(status_summary)()
         assert result["success"] is True
-        mock_direct_api._request.assert_called_with("GET", "statuslabels/assets")
+        assert result["summary"] == {"Ready to Deploy": 50, "Pending": 10}
+        assert result["status_labels"] == 2
+        assert result["total_assets"] == 60
+        mock_direct_api._request.assert_called_with(
+            "GET", "statuslabels", params={"limit": 500, "offset": 0}
+        )
+
+    def test_paginates_past_limit(self, mock_direct_api):
+        from snipeit_mcp import status_summary
+        mock_direct_api._request.side_effect = [
+            {"total": 501, "rows": [{"name": f"Status {i}", "assets_count": 1} for i in range(500)]},
+            {"total": 501, "rows": [{"name": "Status 500", "assets_count": 1}]},
+        ]
+        result = get_tool_fn(status_summary)()
+        assert result["success"] is True
+        assert result["status_labels"] == 501
+        assert result["total_assets"] == 501
+
+    def test_null_assets_count(self, mock_direct_api):
+        from snipeit_mcp import status_summary
+        mock_direct_api._request.return_value = {
+            "total": 1,
+            "rows": [{"name": "Archived", "assets_count": None}],
+        }
+        result = get_tool_fn(status_summary)()
+        assert result["success"] is True
+        assert result["summary"] == {"Archived": 0}
 
 class TestAuditTracking:
     def test_due(self, mock_direct_api):

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -90,3 +90,37 @@ class TestClientErrors:
         mock_client.assets.get.side_effect = SnipeITNotFoundError("Asset 999 not found")
         result = get_tool_fn(asset_operations)(action="checkin", asset_id=999)
         assert result["success"] is False
+
+
+class TestDirectApiRequest:
+    def test_error_status_payload_raises(self):
+        # Snipe-IT returns HTTP 200 with {"status": "error"} for many
+        # failures; _request must raise instead of returning it as success.
+        from unittest.mock import MagicMock, patch
+
+        import pytest
+
+        from snipeit_mcp.client import SnipeITDirectAPI, SnipeITException
+
+        api = SnipeITDirectAPI()
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {
+            "status": "error", "messages": "Statuslabel not found", "payload": None
+        }
+        with patch("snipeit_mcp.client.requests.request", return_value=response):
+            with pytest.raises(SnipeITException, match="Statuslabel not found"):
+                api._request("GET", "statuslabels/assets")
+
+    def test_success_status_payload_passes_through(self):
+        from unittest.mock import MagicMock, patch
+
+        from snipeit_mcp.client import SnipeITDirectAPI
+
+        api = SnipeITDirectAPI()
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"status": "success", "payload": {"id": 1}}
+        with patch("snipeit_mcp.client.requests.request", return_value=response):
+            result = api._request("POST", "hardware", json={})
+        assert result == {"status": "success", "payload": {"id": 1}}


### PR DESCRIPTION
Fixes #18.

## Problem

`status_summary` wraps `GET /statuslabels/assets`, an endpoint removed in Snipe-IT v8.x. The API answers HTTP 200 with `{"status": "error", "messages": "Statuslabel not found"}`, and the tool passed that payload through under `"success": true`, so the failure was easy to miss.

## Changes

- **`status_summary`** now pages through `GET /statuslabels` and aggregates each label's `assets_count`, returning:
  ```json
  {"success": true, "summary": {"Ready to Deploy": 42, "Pending": 0}, "status_labels": 2, "total_assets": 42}
  ```
  Pagination loops past the 500-row limit instead of silently truncating.
- **`SnipeITDirectAPI._request`** now raises `SnipeITException` whenever Snipe-IT returns HTTP 200 with a `{"status": "error", ...}` body (the issue's "additional context" suggestion, applied at the client layer). No tool was checking for this pattern, so every direct-API tool could previously report wrapped errors as success; they now all surface as `{"success": false, "error": ...}` via existing exception handlers.
- Updated `TestStatusSummary` for the new endpoint/shape plus pagination and null-`assets_count` cases; added `TestDirectApiRequest` covering the 200-with-error-payload check.
- CHANGELOG entries added under `[Unreleased]` alongside the FastMCP 3 upgrade (rebased on current main; no version bump — the next release can cut both together).

## Testing

- Full unit suite on top of current main (FastMCP 3): 323 passed.
- End-to-end simulation of a v8 API using the `responses` library against the real `SnipeITDirectAPI` + tool code (only the HTTP layer mocked), verifying: correct aggregation and query params, the exact v8 error payload raising properly, tool-level `success: false` on wrapped errors, and pagination across two pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7eYiYUhJMfDKjLTinu4Wi