### PR TITLE
Cut 1.7.1: version the #18 fixes as their own release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,7 @@ All notable changes to the Snipe-IT MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Changed
-- Upgraded the FastMCP dependency to 3.x (`fastmcp>=3.0.0,<4.0.0`); FastMCP 2.x
-  is no longer supported. The `SNIPEIT_ALLOWED_TOOLS` whitelist was reworked to
-  use FastMCP 3's tool visibility controls (`enable`/`disable`) in place of the
-  removed private tool registry — disabled tools stay registered but are hidden
-  from clients — and behaves the same as before from a user's perspective. The
-  public tool set, input schemas, and stdio transport are unchanged.
+## [1.7.1] - 2026-08-24
 
 ### Fixed
 - `status_summary` no longer calls the removed `statuslabels/assets` endpoint
@@ -23,6 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Direct API requests now raise an error when Snipe-IT returns HTTP 200 with a
   `{"status": "error", ...}` payload, so wrapped API failures are no longer
   reported as `"success": true`.
+
+## [1.7.0] - 2026-06-08
+
+### Changed
+- Upgraded the FastMCP dependency to 3.x (`fastmcp>=3.0.0,<4.0.0`); FastMCP 2.x
+  is no longer supported. The `SNIPEIT_ALLOWED_TOOLS` whitelist was reworked to
+  use FastMCP 3's tool visibility controls (`enable`/`disable`) in place of the
+  removed private tool registry — disabled tools stay registered but are hidden
+  from clients — and behaves the same as before from a user's perspective. The
+  public tool set, input schemas, and stdio transport are unchanged.
 
 ## [1.2.0] - 2025-01-21
 
@@ -156,6 +158,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - UV package manager support
 - Stdio transport for MCP communication
 
+[1.7.1]: https://github.com/jameshgordy/snipeit-mcp/releases/tag/1.7.1
+[1.7.0]: https://github.com/jameshgordy/snipeit-mcp/releases/tag/1.7
 [1.2.0]: https://github.com/jameshgordy/snipeit-mcp/releases/tag/v1.2.0
 [0.3.0]: https://github.com/jameshgordy/snipeit-mcp/releases/tag/v0.3.0
 [0.2.0]: https://github.com/jameshgordy/snipeit-mcp/releases/tag/v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "snipeit-mcp"
-version = "1.6.0"
+version = "1.7.1"
 description = "MCP server for Snipe-IT inventory management system"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Versioning housekeeping so releases are properly staggered:

- The FastMCP 3 upgrade already shipped as **v1.7.0** (tag `1.7`, 2026-06-08) but was still listed under `[Unreleased]` — moved into its own dated changelog section.
- The `status_summary` v8 fix + wrapped-API-error surfacing from #19 become **1.7.1**.
- `pyproject.toml` bumped 1.6.0 → 1.7.1 (it had not been bumped since 1.6.0 despite the 1.7 release).

Full suite passes: 323 tests. A `1.7.1` tag + GitHub release will be cut after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7eYiYUhJMfDKjLTinu4Wi