### PR TITLE
Cut 1.9.0: release the multi-identity mode from #22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Snipe-IT MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.9.0] - 2026-08-27
 
 ### Added
 - **Multi-identity mode** (Mode C, `AuthMode.MULTI_IDENTITY`): one container

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "snipeit-mcp"
-version = "1.8.0"
+version = "1.9.0"
 description = "MCP server for Snipe-IT inventory management system"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "snipeit-mcp"
-version = "1.8.0"
+version = "1.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Version bump to 1.9.0 (pyproject + uv.lock) and dates the Unreleased changelog section, releasing the multi-identity feature merged in #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gu2E2iKNWsb6NVhneE5TYH